### PR TITLE
“title element” → “title attribute”

### DIFF
--- a/index.html
+++ b/index.html
@@ -745,7 +745,7 @@ customElements.define("toggle-button", ToggleButton, { extends: "button" });
 					element available, we can also use <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute">aria-labelledby</a> and reference the HTML id of
 					the existing element.
 					The HTML <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title">title</a>
-					element is not well supported by assistive technologies, so it should not be used to do this.
+					attribute is not well supported by assistive technologies, so it should not be used to do this.
 				</p>
 				<p>
 					Here it really helps to test your UI in a screenreader so that you can figure out where


### PR DESCRIPTION
It’s talking about the global attribute in this place, not the element.